### PR TITLE
[CXF-6506] Client-side message context value HTTP_REQUEST_HEADERS is not shared between SOAP handlers

### DIFF
--- a/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/handler/soap/SOAPMessageContextImpl.java
+++ b/rt/frontend/jaxws/src/main/java/org/apache/cxf/jaxws/handler/soap/SOAPMessageContextImpl.java
@@ -130,7 +130,7 @@ public class SOAPMessageContextImpl extends WrappedMessageContext implements SOA
                 if (!isRequestor() && isOutbound() && MessageContext.HTTP_RESPONSE_HEADERS.equals(key)) {
                     return null;
                 }
-                if (isRequestor() && isOutbound() && MessageContext.HTTP_REQUEST_HEADERS.equals(key)) {
+                if (isRequestor() && !isOutbound() && MessageContext.HTTP_REQUEST_HEADERS.equals(key)) {
                     return null;
                 }
             }

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/handlers/HandlerInvocationTest.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/handlers/HandlerInvocationTest.java
@@ -1225,6 +1225,17 @@ public class HandlerInvocationTest extends AbstractBusClientServerTestBase {
 
     }
 
+    @Test
+    public void testHandlerMessgeContext() throws PingException {
+        MessageContextFirstHandler handler1 = new MessageContextFirstHandler();
+        MessageContextSecondHandler handler2 = new MessageContextSecondHandler();
+        addHandlersToChain((BindingProvider)handlerTest, handler1, handler2);
+
+        List<String> resp = handlerTest.ping();
+        assertNotNull(resp);
+        assertNotNull("handler2 can't retrieve header map from message context", handler2.getHeaderMap());
+    }
+
     void addHandlersToChain(BindingProvider bp, Handler<?>... handlers) {
         @SuppressWarnings("rawtypes")
         List<Handler> handlerChain = bp.getBinding().getHandlerChain();

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/handlers/MessageContextFirstHandler.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/handlers/MessageContextFirstHandler.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systest.handlers;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.namespace.QName;
+import javax.xml.ws.handler.MessageContext;
+import javax.xml.ws.handler.soap.SOAPHandler;
+import javax.xml.ws.handler.soap.SOAPMessageContext;
+
+public class MessageContextFirstHandler implements SOAPHandler<SOAPMessageContext> {
+
+    @Override
+    public boolean handleMessage(SOAPMessageContext context) {
+        boolean isOutbound = (boolean)context.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY);
+        if (isOutbound) {
+            @SuppressWarnings("unchecked")
+            Map<String, List<String>> headerMap = (Map<String, List<String>>)context
+                .get(MessageContext.HTTP_REQUEST_HEADERS);
+            if (headerMap == null) {
+                headerMap = new HashMap<String, List<String>>();
+            }
+            // Add custom header.
+            headerMap.put("MY_HEADER", Arrays.asList("FIRST_VALUE"));
+            context.put(MessageContext.HTTP_REQUEST_HEADERS, headerMap);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean handleFault(SOAPMessageContext context) {
+        return true;
+    }
+
+    @Override
+    public void close(MessageContext context) {
+    }
+
+    @Override
+    public Set<QName> getHeaders() {
+        return null;
+    }
+
+}

--- a/systests/jaxws/src/test/java/org/apache/cxf/systest/handlers/MessageContextSecondHandler.java
+++ b/systests/jaxws/src/test/java/org/apache/cxf/systest/handlers/MessageContextSecondHandler.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.cxf.systest.handlers;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.namespace.QName;
+import javax.xml.ws.handler.MessageContext;
+import javax.xml.ws.handler.soap.SOAPHandler;
+import javax.xml.ws.handler.soap.SOAPMessageContext;
+
+public class MessageContextSecondHandler implements SOAPHandler<SOAPMessageContext> {
+
+    private Map<String, List<String>> headerMap;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean handleMessage(SOAPMessageContext context) {
+        boolean isOutbound = (boolean)context.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY);
+        if (isOutbound) {
+            headerMap = (Map<String, List<String>>)context.get(MessageContext.HTTP_REQUEST_HEADERS);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean handleFault(SOAPMessageContext context) {
+        return true;
+    }
+
+    @Override
+    public void close(MessageContext context) {
+    }
+
+    @Override
+    public Set<QName> getHeaders() {
+        return null;
+    }
+    
+    public Map<String, List<String>> getHeaderMap() {
+        return headerMap;
+    }
+
+}


### PR DESCRIPTION
Backport of CXF-6506 into jboss-2.7.18.SP branch. Requested for EAP 6.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1368905

Original commits to apache/cxf 3.0.x-fixes:
apache@e3f17da
apache@ff6ad65