### PR TITLE
[BZ-1403939] @javax.jws.Oneway causes security-context to be lost

### DIFF
--- a/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/SoapMessage.java
+++ b/rt/bindings/soap/src/main/java/org/apache/cxf/binding/soap/SoapMessage.java
@@ -27,6 +27,7 @@ import javax.xml.namespace.QName;
 
 import org.apache.cxf.headers.Header;
 import org.apache.cxf.helpers.CastUtils;
+import org.apache.cxf.interceptor.OneWayProcessorInterceptor;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.message.MessageImpl;
 
@@ -89,6 +90,20 @@ public class SoapMessage extends MessageImpl {
     public boolean hasAdditionalEnvNs() {
         Map<String, String> ns = getEnvelopeNs();
         return ns != null && !ns.isEmpty();
-    } 
+    }
+
+    @Override
+    public Object getContextualProperty(String key) {
+        Object property = super.getContextualProperty(key);
+
+        // BZ-1403939 Picketbox uses thread local variables for authorization. By running in another thread,
+        // these will be lost.
+        if (OneWayProcessorInterceptor.USE_ORIGINAL_THREAD.equals(key)) {
+            setContextualProperty(OneWayProcessorInterceptor.USE_ORIGINAL_THREAD, true);
+            return true;
+        }
+
+        return property;
+    }
     
 }


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1403939

All SOAP messages must have USE_ORIGINAL_THREAD set to true. Picketbox is unable to provide security context to SOAP messages processed in different threads. See BZ for details.

Note: since contextual properties are set lazily in MessageImpl, we need to specify USE_ORIGINAL_THREAD in the getContextualProperty method.