### PR TITLE
[JBWS-4097] JAXB doesn't (un)marshall property with @XmlElementRef

### DIFF
--- a/rt/databinding/jaxb/src/main/java/org/apache/cxf/jaxb/JAXBDataBinding.java
+++ b/rt/databinding/jaxb/src/main/java/org/apache/cxf/jaxb/JAXBDataBinding.java
@@ -47,6 +47,7 @@ import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.ValidationEventHandler;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementRef;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import javax.xml.namespace.QName;
@@ -798,6 +799,12 @@ public class JAXBDataBinding extends AbstractInterceptorProvidingDataBinding
                 && partName.equals(el.name())) {
                 return field;
             }
+
+            XmlElementRef xmlElementRefAnnotation = field.getAnnotation(XmlElementRef.class);
+            if (xmlElementRefAnnotation != null && partName.equals(xmlElementRefAnnotation.name())) {
+                return field;
+            }
+
             if (field.getName().equals(fieldName)) {
                 return field;
             }


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/JBWS-4097

Current implementation seems to ignore properties with @XmlElementRef annotation.

This is serious since JAX-WS generators do use this annotation in output code.